### PR TITLE
タスクの並び替え処理を修正

### DIFF
--- a/src/modules/task.js
+++ b/src/modules/task.js
@@ -56,12 +56,8 @@ export default {
     }
   },
 
-  async updateProgress(taskId, progress) {
-    await db.collection('tasks').doc(taskId).update({ progress })
-  },
-
-  async updateOrder(tasks) {
-    await Promise.all(tasks.map((task, index) => db.collection('tasks').doc(task.id).update({ order_id: index })))
+  async dragUpdate(tasks, progress) {
+    await Promise.all(tasks.map((task, index) => db.collection('tasks').doc(task.id).update({ order_id: index, progress: progress })))
   },
 
   async fetchComments(taskId) {


### PR DESCRIPTION
タスクを絞り込んだ後に並び替えを行うと並び順の整合性が合わなくなるのを修正